### PR TITLE
Mithrilv0.2.3 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,11 @@
   "bugs": {
     "url": "https://github.com/barneycarroll/mithril.exitable.js/issues"
   },
-  "homepage": "https://github.com/barneycarroll/mithril.exitable.js#readme"
+  "homepage": "https://github.com/barneycarroll/mithril.exitable.js#readme",
+  "dependencies" : {
+    "es6-collections" : "0.5.5"
+  },
+  "peerDependencies": {
+    "mithril" : "^0.2.0"
+  }
 }

--- a/src/exitable.es3.js
+++ b/src/exitable.es3.js
@@ -93,16 +93,16 @@ window.m = ( function( mithril ){
           reverting = true
 
           // Next draw should not patch, only diff
-          m.redraw.strategy( 'none' )
+          mithril.redraw.strategy( 'none' )
 
           // Force a synchronous draw despite being frozen
-          m.redraw( true )
+          mithril.redraw( true )
 
           // Now it's as if we were never here to begin with
           reverting = false
 
           // Resume business as usual
-          m.endComputation()
+          mithril.endComputation()
         } )
       }
 

--- a/src/exitable.es3.js
+++ b/src/exitable.es3.js
@@ -140,7 +140,7 @@ window.m = ( function( mithril ){
 
   // Core m function needs to sniff out components...
   function m( first ){
-    if( 'view' in first )
+    if( Object.prototype.hasOwnProperty.call( object, 'view' ) )
       return m.component.apply( this, arguments )
 
     var output = mithril.apply( this, arguments )

--- a/src/exitable.es3.js
+++ b/src/exitable.es3.js
@@ -140,7 +140,7 @@ window.m = ( function( mithril ){
 
   // Core m function needs to sniff out components...
   function m( first ){
-    if( Object.prototype.hasOwnProperty.call( object, 'view' ) )
+    if( Object.prototype.hasOwnProperty.call( first, 'view' ) )
       return m.component.apply( this, arguments )
 
     var output = mithril.apply( this, arguments )

--- a/src/exitable.es3.js
+++ b/src/exitable.es3.js
@@ -139,7 +139,10 @@ window.m = ( function( mithril ){
   }
 
   // Core m function needs to sniff out components...
-  function m(){
+  function m( first ){
+    if( 'view' in first )
+      return m.component.apply( this, arguments )
+
     var output = mithril.apply( this, arguments )
 
     for( var i = 0; i < output.children.length; i++ )

--- a/src/exitable.es3.js
+++ b/src/exitable.es3.js
@@ -140,7 +140,7 @@ window.m = ( function( mithril ){
 
   // Core m function needs to sniff out components...
   function m( first ){
-    if( Object.prototype.hasOwnProperty.call( first, 'view' ) )
+    if( first.view )
       return m.component.apply( this, arguments )
 
     var output = mithril.apply( this, arguments )


### PR DESCRIPTION
As of 2369958 this seems to work using [the new `m` signature overload](http://mithril.js.org/mithril.html#component-shorthand): https://jsfiddle.net/barney/mgytfqbr/
