### PR TITLE
Proposed fix for #16

### DIFF
--- a/src/exitable.es3.js
+++ b/src/exitable.es3.js
@@ -32,8 +32,11 @@
         var config = node.attrs.config
 
         // Map the root / first child element to the component instance
-        node.attrs.config = function superConfig( el ){
+        node.attrs.config = function superConfig( el, init, ctxt, snapshot ){
           roots.set( ctrl, el )
+          
+          if( history.has( ctrl )
+            history.set( ctrl, snapshot )
 
           if( config )
             return config.apply( this, arguments )


### PR DESCRIPTION
The root view trap can't capture a fully computed virtual DOM snapshot because of Mithril's deferred computation of nested components. This should solve the problem by capturing fully computed snapshots post render.
